### PR TITLE
fix document_number undefined in start count asset button in create p…

### DIFF
--- a/src/app/_components/loading.tsx
+++ b/src/app/_components/loading.tsx
@@ -51,7 +51,6 @@ export const LoadingTableSkeleton = () => {
   const media = useWindowSize()
   const rows = Array.from({ length: 5 }); // 5 loading rows
   const columns = Array.from({ length: media.width as number < 500 ? 1 : 5})
-  console.log(media)
 
   return (
     <TableContainer component={Paper}>

--- a/src/app/_components/planComponent.tsx
+++ b/src/app/_components/planComponent.tsx
@@ -286,15 +286,20 @@ export default function CreatePlanComponent(props: {
           for (const location of (reportForm as unknown as TReportForm).asset_count_location) {
             await CreateAssetCountLocation(location, assetCountReport.id)
           }
-          setReportForm((prev) => ({
-            ...prev,
+          const newReport : TReportForm = {
             id: assetCountReport.id,
+            document_name: assetCountReport.document_name as string,
             document_number: assetCountReport.document_number,
             document_date: assetCountReport.document_date,
+            created_by: assetCountReport.created_by as number,
             state: assetCountReport.state as ReportState,
             asset_count_location: (reportForm as unknown as TReportForm).asset_count_location
+          }
+          setReportForm((prev) => ({
+            ...prev,
+            newReport
           }))
-          setReportList((prev) => [...prev, reportForm])
+          setReportList((prev) => [...prev, newReport])
         }
       }
     }


### PR DESCRIPTION
…lan component

## Summary by Sourcery

Construct and use a complete newReport object in CreatePlanComponent to initialize all report fields before updating state, and clean up a debug log in the loading component.

Bug Fixes:
- Fix undefined document_number and other missing fields by building and setting a complete newReport object in CreatePlanComponent before updating state

Chores:
- Remove stray console.log from LoadingTableSkeleton